### PR TITLE
Fixed form element id conflict. Used nkeyAuthenticator which is speci…

### DIFF
--- a/nodes/nats-suite-server.html
+++ b/nodes/nats-suite-server.html
@@ -62,9 +62,27 @@
       
       updateAuthFields();
       updateTLSFields();
-      
+
+      // Sync nkeySeed value to the nkey-only textarea on open
+      $('#node-config-input-nkeySeed-nkey').val($('#node-config-input-nkeySeed').val());
+
+      // Keep both nkeySeed fields in sync as the user types
+      $('#node-config-input-nkeySeed').on('input', function() {
+        $('#node-config-input-nkeySeed-nkey').val($(this).val());
+      });
+      $('#node-config-input-nkeySeed-nkey').on('input', function() {
+        $('#node-config-input-nkeySeed').val($(this).val());
+      });
+
       $('#node-config-input-authMethod').on('change', updateAuthFields);
       $('#node-config-input-enableTLS').on('change', updateTLSFields);
+    },
+    oneditsave: function() {
+      // Ensure the nkey-only field value is written back to the credential field Node-RED reads
+      const nkeyVal = $('#node-config-input-nkeySeed-nkey').val();
+      if ($('#node-config-input-authMethod').val() === 'nkey' && nkeyVal) {
+        $('#node-config-input-nkeySeed').val(nkeyVal);
+      }
     }
   });
 </script>
@@ -295,7 +313,7 @@
         <div id="auth-nkey-section" class="nats-auth-section">
           <div class="nats-form-row">
             <label><i class="fa fa-fingerprint"></i>NKey Seed</label>
-            <textarea id="node-config-input-nkeySeed" rows="2" placeholder="Paste NKey seed here..."></textarea>
+            <textarea id="node-config-input-nkeySeed-nkey" rows="2" placeholder="Paste NKey seed here..."></textarea>
           </div>
         </div>
         

--- a/nodes/nats-suite-server.js
+++ b/nodes/nats-suite-server.js
@@ -36,7 +36,7 @@ module.exports = function (RED) {
       }
     }
     if (this.authMethod === 'nkey' && this.nkeySeed.length == 0) {
-      this.error(`  - Auth Method: ${this.authMethod} requires the nkeySeed to be set.`);
+      this.error(`[NATS] Auth Method: ${this.authMethod} requires the nkeySeed to be set.`);
     }
     
     // Debug connection info

--- a/nodes/nats-suite-server.js
+++ b/nodes/nats-suite-server.js
@@ -1,4 +1,4 @@
-const { connect, StringCodec, credsAuthenticator } = require('nats');
+const { connect, StringCodec, credsAuthenticator, nkeyAuthenticator } = require('nats');
 const fs = require('fs');
 const path = require('path');
 
@@ -34,6 +34,9 @@ module.exports = function (RED) {
         this.log(`  - TLS Key File: ${this.tlsKeyFile || 'none'}`);
         this.log(`  - Verify Certificate: ${this.tlsRejectUnauthorized}`);
       }
+    }
+    if (this.authMethod === 'nkey' && this.nkeySeed.length == 0) {
+      this.error(`  - Auth Method: ${this.authMethod} requires the nkeySeed to be set.`);
     }
     
     // Debug connection info
@@ -174,7 +177,7 @@ module.exports = function (RED) {
         case 'nkey':
           if (this.nkeySeed) {
             // NKey authentication
-            ConnectionOptions.authenticator = credsAuthenticator(
+            ConnectionOptions.authenticator = nkeyAuthenticator(
               new TextEncoder().encode(this.nkeySeed)
             );
             if (isDebug) this.log(`[NATS] Using NKey authentication`);


### PR DESCRIPTION
nkey-only authentication is critical for IoT applications and also demo'ing NATs security to team members quickly for evaluation and adoption.
This PR fixes the settings form so nkey-only seed textarea has a unique form element id, while sharing the nkey seed value with the other nkey form element under the jwt+nkey Authentication Type. It prints an error msg in case the nkey seed is omitted. Finally, it now uses the nkeyAuthenticator since credsAuthenticator only supports the jwt-plus-nkey configuration.